### PR TITLE
Fix quoted record labels

### DIFF
--- a/src/Language/PS/CST/Printers.purs
+++ b/src/Language/PS/CST/Printers.purs
@@ -15,7 +15,7 @@ import Effect.Exception.Unsafe as Effect.Exception.Unsafe
 import Language.PS.CST.Printers.PrintImports (printImports)
 import Language.PS.CST.Printers.PrintModuleModuleNameAndExports (printModuleModuleNameAndExports)
 import Language.PS.CST.Printers.TypeLevel (printConstraint, printDataCtor, printDataHead, printFixity, printFundep, printKind, printQualifiedName_AnyOpNameType, printQualifiedName_AnyProperNameType, printQualifiedName_Ident, printType, printTypeVarBinding)
-import Language.PS.CST.Printers.Utils (dot, exprShouldBeOnNextLine, maybeWrapInParentheses, parens, printAndConditionallyAddNewlinesBetween, pursParensWithoutGroup, shouldBeNoNewlineBetweenDeclarations, shouldBeNoNewlineBetweenInstanceBindings, shouldBeNoNewlineBetweenLetBindings)
+import Language.PS.CST.Printers.Utils (dot, dquotesIf, exprShouldBeOnNextLine, labelNeedsQuotes, maybeWrapInParentheses, parens, printAndConditionallyAddNewlinesBetween, pursParensWithoutGroup, shouldBeNoNewlineBetweenDeclarations, shouldBeNoNewlineBetweenInstanceBindings, shouldBeNoNewlineBetweenLetBindings)
 import Language.PS.CST.ReservedNames (appendUnderscoreIfReserved, quoteIfReserved)
 import Language.PS.CST.Types.Declaration (Binder(..), Declaration(..), Expr(..), FixityOp(..), Foreign(..), Guarded(..), Instance, InstanceBinding(..), LetBinding(..), RecordUpdate(..), Type(..), ValueBindingFields)
 import Language.PS.CST.Types.Leafs (Comments(..), DeclDeriveType(..), RecordLabeled(..))
@@ -245,7 +245,8 @@ printBinder (BinderOp binderLeft operator binderRight) = printBinder binderLeft 
 
 printRecordLabeled :: ∀ a . (a -> Doc Void) -> RecordLabeled a -> Doc Void
 printRecordLabeled _ (RecordPun ident) = (text <<< quoteIfReserved <<< unwrap) ident
-printRecordLabeled print (RecordField label a) = (text <<< quoteIfReserved <<< unwrap) label <> text ":" <+> print a
+printRecordLabeled print (RecordField label a) =
+  (dquotesIf (labelNeedsQuotes label) <<< text <<< unwrap) label <> text ":" <+> print a
 
 printExpr :: Expr -> Doc Void
 printExpr =

--- a/src/Language/PS/CST/Printers/TypeLevel.purs
+++ b/src/Language/PS/CST/Printers/TypeLevel.purs
@@ -1,14 +1,14 @@
 module Language.PS.CST.Printers.TypeLevel where
 
-import Dodo (Doc, alignCurrentColumn, flexGroup, foldWithSeparator, isEmpty, paragraph, softBreak, space, spaceBreak, text, (<+>))
 import Prelude
 
 import Data.Array as Array
 import Data.Foldable (null)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Newtype (unwrap)
-import Language.PS.CST.Printers.Utils (dquotes, maybeWrapInParentheses, parens, printModuleName)
-import Language.PS.CST.ReservedNames (appendUnderscoreIfReserved, quoteIfReserved)
+import Dodo (Doc, alignCurrentColumn, flexGroup, foldWithSeparator, isEmpty, paragraph, softBreak, space, spaceBreak, text, (<+>))
+import Language.PS.CST.Printers.Utils (dquotes, dquotesIf, labelNeedsQuotes, maybeWrapInParentheses, parens, printModuleName)
+import Language.PS.CST.ReservedNames (appendUnderscoreIfReserved)
 import Language.PS.CST.Types.Declaration (Constraint(..), DataCtor(..), DataHead(..), Kind(..), Row, Type(..), TypeVarBinding(..))
 import Language.PS.CST.Types.Leafs (ClassFundep(..), Fixity(..), Ident, Label, OpName, ProperName)
 import Language.PS.CST.Types.QualifiedName (QualifiedName(..))
@@ -154,4 +154,4 @@ printRowLikeType leftWrapper rightWrapper row =
                 ]
 
 printRowLabel :: { label :: Label, type_ :: Type } -> Doc Void
-printRowLabel { label, type_ } = (text <<< quoteIfReserved <<< unwrap) label <+> text "::" <+> printType type_
+printRowLabel { label, type_ } = (dquotesIf (labelNeedsQuotes label) <<< text <<< unwrap) label <+> text "::" <+> printType type_

--- a/src/Language/PS/CST/Printers/Utils.purs
+++ b/src/Language/PS/CST/Printers/Utils.purs
@@ -16,6 +16,10 @@ import Language.PS.CST.Types.Leafs (ModuleName(..), ProperName, ProperNameType_C
 dquotes :: forall a. Doc a -> Doc a
 dquotes = enclose dquote dquote
 
+dquotesIf :: forall a. Boolean -> Doc a -> Doc a
+dquotesIf true = dquotes
+dquotesIf false = identity
+
 dquote :: forall a. Doc a
 dquote = text "\""
 

--- a/src/Language/PS/CST/Printers/Utils.purs
+++ b/src/Language/PS/CST/Printers/Utils.purs
@@ -2,14 +2,20 @@ module Language.PS.CST.Printers.Utils where
 
 import Prelude
 
+import Data.Either (fromRight)
 import Data.Foldable (class Foldable)
 import Data.List (List(..), (:))
 import Data.List (fromFoldable) as List
 import Data.Maybe (Maybe(..))
 import Data.Newtype (unwrap)
+import Data.String.Regex (Regex, regex)
+import Data.String.Regex as Regex
+import Data.String.Regex.Flags as RegexFlags
 import Dodo (Doc, break, enclose, encloseEmptyAlt, flexAlt, foldWithSeparator, softBreak, text)
+import Language.PS.CST.ReservedNames (isReservedName)
 import Language.PS.CST.Types.Declaration (Declaration(..), Expr(..), InstanceBinding(..), LetBinding(..))
-import Language.PS.CST.Types.Leafs (ModuleName(..), ProperName, ProperNameType_ConstructorName)
+import Language.PS.CST.Types.Leafs (Label(..), ModuleName(..), ProperName, ProperNameType_ConstructorName)
+import Partial.Unsafe (unsafePartial)
 
 -- | >>> dquotes "·"
 -- "·"
@@ -93,3 +99,11 @@ exprShouldBeOnNextLine (ExprLet _) = true
 exprShouldBeOnNextLine (ExprCase _) = true
 exprShouldBeOnNextLine (ExprIf _) = true
 exprShouldBeOnNextLine _ = false
+
+labelNeedsQuotes :: Label -> Boolean
+labelNeedsQuotes (Label name) =
+  isReservedName name || not (Regex.test unquotedLabelRegex name)
+
+unquotedLabelRegex :: Regex
+unquotedLabelRegex =
+  unsafePartial $ fromRight $ regex "^[a-z][A-Za-z0-9_]*$" RegexFlags.noFlags

--- a/src/Language/PS/CST/ReservedNames.purs
+++ b/src/Language/PS/CST/ReservedNames.purs
@@ -32,14 +32,17 @@ reservedNames = Set.fromFoldable
   , "where"
   ]
 
+isReservedName :: String -> Boolean
+isReservedName str = Set.member str reservedNames
+
 appendUnderscoreIfReserved :: String -> String
 appendUnderscoreIfReserved str =
-  if Set.member str reservedNames
+  if isReservedName str
     then str <> "_"
     else str
 
 quoteIfReserved :: String -> String
 quoteIfReserved str =
-  if Set.member str reservedNames
+  if isReservedName str
     then "\"" <> str <> "\""
     else str

--- a/test/Golden/DeclType/Actual.purs
+++ b/test/Golden/DeclType/Actual.purs
@@ -81,6 +81,10 @@ actualModule = Module
                                 )
       }
     , declFooType $ TypeRow
+      { rowLabels: mkRowLabels [ "RowField" /\ numberType ]
+      , rowTail: Nothing
+      }
+    , declFooType $ TypeRow
       { rowLabels: mkRowLabels
         [ "rowField" /\ (typeRecord
           [ "foo" /\ numberType

--- a/test/Golden/DeclType/Expected.txt
+++ b/test/Golden/DeclType/Expected.txt
@@ -64,6 +64,8 @@ type Foo = ( rowField :: Number
                            { someField :: Number }
            )
 
+type Foo = ( "RowField" :: Number )
+
 type Foo = ( rowField :: { foo :: Number
                          , bar :: Data.Map.Map
                                   (Data.Map.Map

--- a/test/Golden/ExprRecord/Actual.purs
+++ b/test/Golden/ExprRecord/Actual.purs
@@ -7,7 +7,7 @@ import Data.Maybe (Maybe(..))
 import Data.Array.NonEmpty as NonEmpty
 
 names :: Array String
-names = ["Human", "Droid"]
+names = ["onHuman", "onDroid", "Cyborg"]
 
 actualModule :: Module
 actualModule = Module
@@ -23,7 +23,7 @@ actualModule = Module
         , guarded: Unconditional
             { expr:
               ExprRecord $ names <#> \name -> RecordField
-                (Label $ "on" <> name)
+                (Label name)
                 ( (ExprIdent $ nonQualifiedName $ Ident "pure")
                   `ExprApp`
                   (ExprConstructor $ nonQualifiedName $ ProperName "Nothing")
@@ -34,4 +34,3 @@ actualModule = Module
       }
     ]
   }
-

--- a/test/Golden/ExprRecord/Expected.txt
+++ b/test/Golden/ExprRecord/Expected.txt
@@ -1,3 +1,9 @@
 module ExprRecord where
 
-maybeFragments = { onHuman: pure Nothing, onDroid: pure Nothing }
+maybeFragments = { onHuman: pure
+                            Nothing
+                 , onDroid: pure
+                            Nothing
+                 , "Cyborg": pure
+                             Nothing
+                 }


### PR DESCRIPTION
Fixing cases for code generation of:

```purescript
type Foo = ( "Bar" :: Int )
```

and

```purescript
type Foo = { "Bar" :: Int }
```

I did check the purescript-cst from the compiler that `Bar` in both instances are read as `(Label "Bar")` (and not `(Label "\"Bar\")`) - so we'll need to add in quoting for that.

I'm not too familiar with the purescript cst syntax definition from the cst's `Parser.y` file though -- so the code for the check whether the label needs quoting though is a guess -- let me know if I should adjust accordingly.

Also, unsure if I placed the code in the correct places -- let me know if I should move them elsewhere.