### PR TITLE
Fix typeop flexgroup

### DIFF
--- a/src/Language/PS/CST/Printers/TypeLevel.purs
+++ b/src/Language/PS/CST/Printers/TypeLevel.purs
@@ -90,6 +90,7 @@ printType = \type_ -> case type_ of
                            (TypeForall _ _) -> flexGroup $ printTypeImplementation type_
                            (TypeConstrained _ _) -> flexGroup $ printTypeImplementation type_
                            (TypeArr _ _) -> flexGroup $ printTypeImplementation type_
+                           (TypeOp _ _ _) -> flexGroup $ printTypeImplementation type_
                            _ -> printTypeImplementation type_
   where
     printTypeImplementation (TypeVar ident) = (text <<< appendUnderscoreIfReserved <<< unwrap) ident

--- a/test/Golden/DeclDataComplex/Expected.txt
+++ b/test/Golden/DeclDataComplex/Expected.txt
@@ -44,8 +44,7 @@ data Foo
     ( rowField :: Number, rowField2 :: Number | MyExtension + MyOtherExtension )
     ( rowField :: Number
     , rowField2 :: Number
-    | MyExtension + MyOtherExtension
-                    { someField :: Number }
+    | MyExtension + MyOtherExtension { someField :: Number }
     )
     ( rowField :: { foo :: Number
                   , bar :: Data.Map.Map

--- a/test/Golden/DeclNewtype/Expected.txt
+++ b/test/Golden/DeclNewtype/Expected.txt
@@ -60,8 +60,7 @@ newtype Foo = Foo ( rowField :: Number
 
 newtype Foo = Foo ( rowField :: Number
                   , rowField2 :: Number
-                  | MyExtension + MyOtherExtension
-                                  { someField :: Number }
+                  | MyExtension + MyOtherExtension { someField :: Number }
                   )
 
 newtype Foo = Foo ( rowField :: { foo :: Number

--- a/test/Golden/DeclType/Actual.purs
+++ b/test/Golden/DeclType/Actual.purs
@@ -140,6 +140,18 @@ actualModule = Module
       (arrayType $ TypeVar $ Ident "a")
     , declFooType $ (arrayType $ TypeVar $ Ident "a") ====>> (maybeType $ TypeVar $ Ident "a")
     , declFooType $ TypeOp (TypeConstructor $ nonQualifiedName $ ProperName "Array") (nonQualifiedName $ OpName "~>") (TypeConstructor $ nonQualifiedName $ ProperName "Maybe")
+    , declFooType $
+      (TypeOp
+       ((TypeConstructor $ nonQualifiedName (ProperName "Foo"))
+        `TypeApp`
+        (TypeConstructor $ nonQualifiedName (ProperName "A"))
+       )
+       (nonQualifiedName (OpName "<+>"))
+       ((TypeConstructor $ nonQualifiedName (ProperName "Foo"))
+        `TypeApp`
+        (TypeConstructor $ nonQualifiedName (ProperName "B"))
+       )
+      )
     , declFooType $ TypeForall
       (NonEmpty.cons' (TypeVarName $ Ident "f") [])
       ( TypeConstrained

--- a/test/Golden/DeclType/Expected.txt
+++ b/test/Golden/DeclType/Expected.txt
@@ -87,6 +87,8 @@ type Foo = (Array a -> Maybe a)
 
 type Foo = (Array ~> Maybe)
 
+type Foo = (Foo A <+> Foo B)
+
 type Foo = (forall f . Functor f => f ~> Maybe)
 
 type Foo = (MyClass f g k => MyClass2 { foo :: Number } => f)

--- a/test/Golden/DeclType/Expected.txt
+++ b/test/Golden/DeclType/Expected.txt
@@ -60,8 +60,7 @@ type Foo = ( rowField :: Number
 
 type Foo = ( rowField :: Number
            , rowField2 :: Number
-           | MyExtension + MyOtherExtension
-                           { someField :: Number }
+           | MyExtension + MyOtherExtension { someField :: Number }
            )
 
 type Foo = ( "RowField" :: Number )


### PR DESCRIPTION
Change from printing:

```
type Foo = (Foo
            A <+> Foo
                  B)
```

to

```
type Foo = (Foo A <+> Foo B)
```