### PR TITLE
Add test case for multiline type op

### DIFF
--- a/test/Golden/DeclDataComplex/Expected.txt
+++ b/test/Golden/DeclDataComplex/Expected.txt
@@ -4,69 +4,66 @@ data Foo
   = Bar
     Boolean
     { foo :: Number
-    , bar :: { baz :: Data.Map.Map String Number }
-    , qwe :: { rty :: Data.Map.Map
-                      { asd :: Number }
-                      { foo :: Number
-                      , bar :: Data.Map.Map
-                               (Data.Map.Map
-                                (Data.Map.Map
-                                 Number
-                                 Boolean)
-                                (Data.Map.Map
-                                 Number
-                                 Boolean))
-                               Boolean
-                      }
-             , uio :: Data.Map.Map
-                      (Data.Map.Map
-                       (Data.Map.Map
-                        Number
-                        Boolean)
-                       (Data.Map.Map
-                        Number
-                        Boolean))
-                      Boolean
-             }
+    , bar :: {baz :: Data.Map.Map String Number}
+    , qwe
+      :: { rty
+           :: Data.Map.Map
+              {asd :: Number}
+              { foo :: Number
+              , bar
+                :: Data.Map.Map
+                   ( Data.Map.Map
+                     (Data.Map.Map Number Boolean)
+                     (Data.Map.Map Number Boolean)
+                   )
+                   Boolean
+              }
+         , uio
+           :: Data.Map.Map
+              ( Data.Map.Map
+                (Data.Map.Map Number Boolean)
+                (Data.Map.Map Number Boolean)
+              )
+              Boolean
+         }
     }
     a
     (Array a)
-    (Array { foo :: Number })
+    (Array {foo :: Number})
     _
     ?myhole
     "PsString"
     ()
-    ( | MyExtension )
-    ( rowField :: Number )
-    ( rowField :: Number | MyExtension )
-    ( rowField :: Number, rowField2 :: Number )
-    ( rowField :: Number, rowField2 :: Number | MyExtension )
-    ( rowField :: Number, rowField2 :: Number | MyExtension + MyOtherExtension )
+    (| MyExtension)
+    (rowField :: Number)
+    (rowField :: Number | MyExtension)
+    (rowField :: Number, rowField2 :: Number)
+    (rowField :: Number, rowField2 :: Number | MyExtension)
+    (rowField :: Number, rowField2 :: Number | MyExtension + MyOtherExtension)
     ( rowField :: Number
     , rowField2 :: Number
-    | MyExtension + MyOtherExtension { someField :: Number }
+    | MyExtension + MyOtherExtension {someField :: Number}
     )
-    ( rowField :: { foo :: Number
-                  , bar :: Data.Map.Map
-                           (Data.Map.Map
-                            (Data.Map.Map
-                             Number
-                             Boolean)
-                            (Data.Map.Map
-                             Number
-                             Boolean))
-                           Boolean
-                  , baz :: Complex A B C D E F G H
-                  , qux :: Complex (A B C) D E (F G H)
-                  , asd :: Complex A B (C (D E) F G) H
-                  , qwe :: Complex (A B C) D E (F (G H))
-                  }
+    ( rowField
+      :: { foo :: Number
+         , bar
+           :: Data.Map.Map
+              ( Data.Map.Map
+                (Data.Map.Map Number Boolean)
+                (Data.Map.Map Number Boolean)
+              )
+              Boolean
+         , baz :: Complex A B C D E F G H
+         , qux :: Complex (A B C) D E (F G H)
+         , asd :: Complex A B (C (D E) F G) H
+         , qwe :: Complex (A B C) D E (F (G H))
+         }
     )
-    (forall a (b :: # Type) . Array a)
+    (forall a (b :: # Type). Array a)
     (Array a -> Maybe a)
     (Array ~> Maybe)
-    (forall f . Functor f => f ~> Maybe)
-    (MyClass f g k => MyClass2 { foo :: Number } => f)
+    (forall f. Functor f => f ~> Maybe)
+    (MyClass f g k => MyClass2 {foo :: Number} => f)
     (MyKindedType :: (CustomKind -> # Type) -> Type)
     (MyKindedType :: CustomKind -> # Type -> Type)
   | Baz Prelude.Boolean

--- a/test/Golden/DeclDerive/Actual.purs
+++ b/test/Golden/DeclDerive/Actual.purs
@@ -94,5 +94,34 @@ actualModule = Module
         , instTypes: NonEmpty.singleton $ (TypeConstructor $ nonQualifiedName $ ProperName "Tuple") `TypeApp` (TypeVar $ Ident "a") `TypeApp` (TypeVar $ Ident "b")
         }
       }
+    , DeclDerive
+      { comments: Nothing
+      , deriveType: DeclDeriveType_Ordinary
+      , head:
+        { instName: Ident "foo"
+        , instConstraints:
+          [ Constraint { className: nonQualifiedName (ProperName "Foo"), args: [TypeVar $ Ident "a"] }
+          , Constraint { className: nonQualifiedName (ProperName "Bar"), args: [TypeVar $ Ident "b", TypeVar $ Ident "c"] }
+          , Constraint { className: nonQualifiedName (ProperName "Partial"), args: [] }
+          , Constraint { className: nonQualifiedName (ProperName "Partial1"), args: [] }
+          , Constraint { className: nonQualifiedName (ProperName "Partial2"), args: [] }
+          , Constraint { className: nonQualifiedName (ProperName "Partial3"), args: [] }
+          , Constraint { className: nonQualifiedName (ProperName "Partial4"), args: [] }
+          , Constraint { className: nonQualifiedName (ProperName "Partial5"), args: [] }
+          , Constraint { className: nonQualifiedName (ProperName "Partial6"), args: [] }
+          , Constraint { className: nonQualifiedName (ProperName "Partial7"), args: [] }
+          ]
+        , instClass: nonQualifiedName $ ProperName "Foo"
+        , instTypes: NonEmpty.singleton $ (TypeConstructor $ nonQualifiedName $ ProperName "Foo")
+          `TypeApp` (TypeVar $ Ident "abcde") `TypeApp` (TypeVar $ Ident "fghij")
+          `TypeApp` (TypeVar $ Ident "abcde") `TypeApp` (TypeVar $ Ident "fghij")
+          `TypeApp` (TypeVar $ Ident "abcde") `TypeApp` (TypeVar $ Ident "fghij")
+          `TypeApp` (TypeVar $ Ident "abcde") `TypeApp` (TypeVar $ Ident "fghij")
+          `TypeApp` (TypeVar $ Ident "abcde") `TypeApp` (TypeVar $ Ident "fghij")
+          `TypeApp` (TypeVar $ Ident "abcde") `TypeApp` (TypeVar $ Ident "fghij")
+          `TypeApp` (TypeVar $ Ident "abcde") `TypeApp` (TypeVar $ Ident "fghij")
+          `TypeApp` (TypeVar $ Ident "abcde") `TypeApp` (TypeVar $ Ident "fghij")
+        }
+      }
     ]
   }

--- a/test/Golden/DeclDerive/Expected.txt
+++ b/test/Golden/DeclDerive/Expected.txt
@@ -4,15 +4,44 @@ derive instance eqBaz :: Eq Baz
 
 derive newtype instance eqBaz :: Eq Baz
 
-derive instance foo :: Foo Bar { foo :: Number }
+derive instance foo :: Foo Bar {foo :: Number}
 
 derive instance foo :: Foo a => Foo (Array a)
 
 derive instance foo :: (Foo a, Bar b c, Partial) => Foo (Tuple a b)
 
-derive instance foo :: ( Foo a
-                       , Bar b c
-                       , Partial
-                       , Partial1
-                       , Partial2
-                       ) => Foo (Tuple a b)
+derive instance foo
+  :: (Foo a, Bar b c, Partial, Partial1, Partial2)
+  => Foo (Tuple a b)
+
+derive instance foo
+  :: ( Foo a
+     , Bar b c
+     , Partial
+     , Partial1
+     , Partial2
+     , Partial3
+     , Partial4
+     , Partial5
+     , Partial6
+     , Partial7
+     )
+  => Foo
+     ( Foo
+       abcde
+       fghij
+       abcde
+       fghij
+       abcde
+       fghij
+       abcde
+       fghij
+       abcde
+       fghij
+       abcde
+       fghij
+       abcde
+       fghij
+       abcde
+       fghij
+     )

--- a/test/Golden/DeclForeign/Actual.purs
+++ b/test/Golden/DeclForeign/Actual.purs
@@ -32,6 +32,10 @@ actualModule = Module
               { rowLabels: mkRowLabels
                 [ "console" /\ (TypeConstructor $ nonQualifiedName $ ProperName "CONSOLE")
                 , "foo" /\ (TypeConstructor $ nonQualifiedName $ ProperName "FOO")
+                , "bar" /\ (TypeConstructor $ nonQualifiedName $ ProperName "BAR")
+                , "baz" /\ (TypeConstructor $ nonQualifiedName $ ProperName "BAZ")
+                , "qux" /\ (TypeConstructor $ nonQualifiedName $ ProperName "QUX")
+                , "quux" /\ (TypeConstructor $ nonQualifiedName $ ProperName "QUUX")
                 ]
               , rowTail: Just $ TypeVar $ Ident "e"
               }

--- a/test/Golden/DeclForeign/Expected.txt
+++ b/test/Golden/DeclForeign/Expected.txt
@@ -4,6 +4,15 @@ foreign import kind Foo
 
 foreign import data Foo :: # Type -> Type
 
-foreign import main_ :: forall e . Eff
-                                   ( console :: CONSOLE, foo :: FOO | e )
-                                   Unit
+foreign import main_
+  :: forall e
+   . Eff
+     ( console :: CONSOLE
+     , foo :: FOO
+     , bar :: BAR
+     , baz :: BAZ
+     , qux :: QUX
+     , quux :: QUUX
+     | e
+     )
+     Unit

--- a/test/Golden/DeclNewtype/Expected.txt
+++ b/test/Golden/DeclNewtype/Expected.txt
@@ -2,38 +2,38 @@ module DeclNewtype where
 
 newtype Foo = Foo Boolean
 
-newtype Foo = Foo { foo :: Number
-                  , bar :: { baz :: Data.Map.Map String Number }
-                  , qwe :: { rty :: Data.Map.Map
-                                    { asd :: Number }
-                                    { foo :: Number
-                                    , bar :: Data.Map.Map
-                                             (Data.Map.Map
-                                              (Data.Map.Map
-                                               Number
-                                               Boolean)
-                                              (Data.Map.Map
-                                               Number
-                                               Boolean))
-                                             Boolean
-                                    }
-                           , uio :: Data.Map.Map
-                                    (Data.Map.Map
-                                     (Data.Map.Map
-                                      Number
-                                      Boolean)
-                                     (Data.Map.Map
-                                      Number
-                                      Boolean))
-                                    Boolean
-                           }
-                  }
+newtype Foo
+  = Foo
+    { foo :: Number
+    , bar :: {baz :: Data.Map.Map String Number}
+    , qwe
+      :: { rty
+           :: Data.Map.Map
+              {asd :: Number}
+              { foo :: Number
+              , bar
+                :: Data.Map.Map
+                   ( Data.Map.Map
+                     (Data.Map.Map Number Boolean)
+                     (Data.Map.Map Number Boolean)
+                   )
+                   Boolean
+              }
+         , uio
+           :: Data.Map.Map
+              ( Data.Map.Map
+                (Data.Map.Map Number Boolean)
+                (Data.Map.Map Number Boolean)
+              )
+              Boolean
+         }
+    }
 
 newtype Foo = Foo a
 
 newtype Foo = Foo (Array a)
 
-newtype Foo = Foo (Array { foo :: Number })
+newtype Foo = Foo (Array {foo :: Number})
 
 newtype Foo = Foo _
 
@@ -43,50 +43,52 @@ newtype Foo = Foo "PsString"
 
 newtype Foo = Foo ()
 
-newtype Foo = Foo ( | MyExtension )
+newtype Foo = Foo (| MyExtension)
 
-newtype Foo = Foo ( rowField :: Number )
+newtype Foo = Foo (rowField :: Number)
 
-newtype Foo = Foo ( rowField :: Number | MyExtension )
+newtype Foo = Foo (rowField :: Number | MyExtension)
 
-newtype Foo = Foo ( rowField :: Number, rowField2 :: Number )
+newtype Foo = Foo (rowField :: Number, rowField2 :: Number)
 
-newtype Foo = Foo ( rowField :: Number, rowField2 :: Number | MyExtension )
+newtype Foo = Foo (rowField :: Number, rowField2 :: Number | MyExtension)
 
-newtype Foo = Foo ( rowField :: Number
-                  , rowField2 :: Number
-                  | MyExtension + MyOtherExtension
-                  )
+newtype Foo
+  = Foo
+    (rowField :: Number, rowField2 :: Number | MyExtension + MyOtherExtension)
 
-newtype Foo = Foo ( rowField :: Number
-                  , rowField2 :: Number
-                  | MyExtension + MyOtherExtension { someField :: Number }
-                  )
+newtype Foo
+  = Foo
+    ( rowField :: Number
+    , rowField2 :: Number
+    | MyExtension + MyOtherExtension {someField :: Number}
+    )
 
-newtype Foo = Foo ( rowField :: { foo :: Number
-                                , bar :: Data.Map.Map
-                                         (Data.Map.Map
-                                          (Data.Map.Map
-                                           Number
-                                           Boolean)
-                                          (Data.Map.Map
-                                           Number
-                                           Boolean))
-                                         Boolean
-                                , baz :: Complex A B C D F G H
-                                , qux :: Complex (A B C) D (F G H)
-                                }
-                  )
+newtype Foo
+  = Foo
+    ( rowField
+      :: { foo :: Number
+         , bar
+           :: Data.Map.Map
+              ( Data.Map.Map
+                (Data.Map.Map Number Boolean)
+                (Data.Map.Map Number Boolean)
+              )
+              Boolean
+         , baz :: Complex A B C D F G H
+         , qux :: Complex (A B C) D (F G H)
+         }
+    )
 
-newtype Foo = Foo (forall a (b :: # Type) . Array a)
+newtype Foo = Foo (forall a (b :: # Type). Array a)
 
 newtype Foo = Foo (Array a -> Maybe a)
 
 newtype Foo = Foo (Array ~> Maybe)
 
-newtype Foo = Foo (forall f . Functor f => f ~> Maybe)
+newtype Foo = Foo (forall f. Functor f => f ~> Maybe)
 
-newtype Foo = Foo (MyClass f g k => MyClass2 { foo :: Number } => f)
+newtype Foo = Foo (MyClass f g k => MyClass2 {foo :: Number} => f)
 
 newtype Foo = Foo (MyKindedType :: (CustomKind -> # Type) -> Type)
 

--- a/test/Golden/DeclType/Actual.purs
+++ b/test/Golden/DeclType/Actual.purs
@@ -169,5 +169,21 @@ actualModule = Module
     , declFooType $ TypeKinded
       (TypeConstructor $ nonQualifiedName $ ProperName "MyKindedType")
       ((KindName $ nonQualifiedName $ ProperName "CustomKind") ====>>> KindRow (KindName $ nonQualifiedName $ ProperName "Type") ====>>> (KindName $ nonQualifiedName $ ProperName "Type"))
+    , declFooType $
+      (TypeConstructor $ nonQualifiedName (ProperName "FooBarBaz"))
+      `TypeApp`
+      (TypeConstructor $ nonQualifiedName (ProperName "QuxQuuxQuz"))
+      ====>>
+      (TypeConstructor $ nonQualifiedName (ProperName "FooBarBaz"))
+      `TypeApp`
+      (TypeConstructor $ nonQualifiedName (ProperName "QuxQuuxQuz"))
+      ====>>
+      (TypeConstructor $ nonQualifiedName (ProperName "FooBarBaz"))
+      `TypeApp`
+      (TypeConstructor $ nonQualifiedName (ProperName "QuxQuuxQuz"))
+      ====>>
+      (TypeConstructor $ nonQualifiedName (ProperName "FooBarBaz"))
+      `TypeApp`
+      (TypeConstructor $ nonQualifiedName (ProperName "QuxQuuxQuz"))
     ]
   }

--- a/test/Golden/DeclType/Expected.txt
+++ b/test/Golden/DeclType/Expected.txt
@@ -2,38 +2,37 @@ module DeclType where
 
 type Foo = Boolean
 
-type Foo = { foo :: Number
-           , bar :: { baz :: Data.Map.Map String Number }
-           , qwe :: { rty :: Data.Map.Map
-                             { asd :: Number }
-                             { foo :: Number
-                             , bar :: Data.Map.Map
-                                      (Data.Map.Map
-                                       (Data.Map.Map
-                                        Number
-                                        Boolean)
-                                       (Data.Map.Map
-                                        Number
-                                        Boolean))
-                                      Boolean
-                             }
-                    , uio :: Data.Map.Map
-                             (Data.Map.Map
-                              (Data.Map.Map
-                               Number
-                               Boolean)
-                              (Data.Map.Map
-                               Number
-                               Boolean))
-                             Boolean
-                    }
-           }
+type Foo
+  = { foo :: Number
+    , bar :: {baz :: Data.Map.Map String Number}
+    , qwe
+      :: { rty
+           :: Data.Map.Map
+              {asd :: Number}
+              { foo :: Number
+              , bar
+                :: Data.Map.Map
+                   ( Data.Map.Map
+                     (Data.Map.Map Number Boolean)
+                     (Data.Map.Map Number Boolean)
+                   )
+                   Boolean
+              }
+         , uio
+           :: Data.Map.Map
+              ( Data.Map.Map
+                (Data.Map.Map Number Boolean)
+                (Data.Map.Map Number Boolean)
+              )
+              Boolean
+         }
+    }
 
 type Foo = a
 
 type Foo = Array a
 
-type Foo = Array { foo :: Number }
+type Foo = Array {foo :: Number}
 
 type Foo = _
 
@@ -43,55 +42,60 @@ type Foo = "PsString"
 
 type Foo = ()
 
-type Foo = ( | MyExtension )
+type Foo = (| MyExtension)
 
-type Foo = ( rowField :: Number )
+type Foo = (rowField :: Number)
 
-type Foo = ( rowField :: Number | MyExtension )
+type Foo = (rowField :: Number | MyExtension)
 
-type Foo = ( rowField :: Number, rowField2 :: Number )
+type Foo = (rowField :: Number, rowField2 :: Number)
 
-type Foo = ( rowField :: Number, rowField2 :: Number | MyExtension )
+type Foo = (rowField :: Number, rowField2 :: Number | MyExtension)
 
-type Foo = ( rowField :: Number
-           , rowField2 :: Number
-           | MyExtension + MyOtherExtension
-           )
+type Foo
+  = (rowField :: Number, rowField2 :: Number | MyExtension + MyOtherExtension)
 
-type Foo = ( rowField :: Number
-           , rowField2 :: Number
-           | MyExtension + MyOtherExtension { someField :: Number }
-           )
+type Foo
+  = ( rowField :: Number
+    , rowField2 :: Number
+    | MyExtension + MyOtherExtension {someField :: Number}
+    )
 
-type Foo = ( "RowField" :: Number )
+type Foo = ("RowField" :: Number)
 
-type Foo = ( rowField :: { foo :: Number
-                         , bar :: Data.Map.Map
-                                  (Data.Map.Map
-                                   (Data.Map.Map
-                                    Number
-                                    Boolean)
-                                   (Data.Map.Map
-                                    Number
-                                    Boolean))
-                                  Boolean
-                         , baz :: Complex A B C D F G H
-                         , qux :: Complex (A B C) D (F G H)
-                         }
-           )
+type Foo
+  = ( rowField
+      :: { foo :: Number
+         , bar
+           :: Data.Map.Map
+              ( Data.Map.Map
+                (Data.Map.Map Number Boolean)
+                (Data.Map.Map Number Boolean)
+              )
+              Boolean
+         , baz :: Complex A B C D F G H
+         , qux :: Complex (A B C) D (F G H)
+         }
+    )
 
-type Foo = (forall a (b :: # Type) . Array a)
+type Foo = forall a (b :: # Type). Array a
 
-type Foo = (Array a -> Maybe a)
+type Foo = Array a -> Maybe a
 
-type Foo = (Array ~> Maybe)
+type Foo = Array ~> Maybe
 
-type Foo = (Foo A <+> Foo B)
+type Foo = Foo A <+> Foo B
 
-type Foo = (forall f . Functor f => f ~> Maybe)
+type Foo = forall f. Functor f => f ~> Maybe
 
-type Foo = (MyClass f g k => MyClass2 { foo :: Number } => f)
+type Foo = MyClass f g k => MyClass2 {foo :: Number} => f
 
-type Foo = (MyKindedType :: (CustomKind -> # Type) -> Type)
+type Foo = MyKindedType :: (CustomKind -> # Type) -> Type
 
-type Foo = (MyKindedType :: CustomKind -> # Type -> Type)
+type Foo = MyKindedType :: CustomKind -> # Type -> Type
+
+type Foo
+  = FooBarBaz QuxQuuxQuz
+  -> FooBarBaz QuxQuuxQuz
+  -> FooBarBaz QuxQuuxQuz
+  -> FooBarBaz QuxQuuxQuz

--- a/test/Golden/ExprArray/Expected.txt
+++ b/test/Golden/ExprArray/Expected.txt
@@ -1,9 +1,9 @@
 module Array where
 
-f :: Array { x :: Int, y :: Boolean }
+f :: Array {x :: Int, y :: Boolean}
 f = [ { x: 1, y: true }, { x: 10, y: false } ]
 
-f :: Array { x :: Int, y :: Boolean }
+f :: Array {x :: Int, y :: Boolean}
 f = [ { x: 1, y: true }
     , { x: 10, y: false }
     , { x: 0, y: true }

--- a/test/Golden/Instance/Actual.purs
+++ b/test/Golden/Instance/Actual.purs
@@ -119,6 +119,10 @@ actualModule = Module
                 (TypeConstructor $ nonQualifiedName $ ProperName "IntLongLongLong")
                 `TypeApp`
                 (TypeConstructor $ nonQualifiedName $ ProperName "BooleanLongLongLong")
+                `TypeApp`
+                (TypeConstructor $ nonQualifiedName $ ProperName "BooleanLongLongLong")
+                `TypeApp`
+                (TypeConstructor $ nonQualifiedName $ ProperName "BooleanLongLongLong")
               ]
             }
           , body:

--- a/test/Golden/Instance/Expected.txt
+++ b/test/Golden/Instance/Expected.txt
@@ -12,9 +12,13 @@ instance fooBaz :: Foo Baz where
 instance fooBaz :: Foo (Cor Int) (Gar Int Boolean) where
   foo = append
 
-instance fooBazLongLongLong :: FooLongLongLong
-                               (CorLongLongLong IntLongLongLong)
-                               (GarLongLongLong
-                                IntLongLongLong
-                                BooleanLongLongLong) where
+instance fooBazLongLongLong
+  :: FooLongLongLong
+     (CorLongLongLong IntLongLongLong)
+     ( GarLongLongLong
+       IntLongLongLong
+       BooleanLongLongLong
+       BooleanLongLongLong
+       BooleanLongLongLong
+     ) where
   foo = append


### PR DESCRIPTION
Added a test case for multiline type arrow / op

Currently though, it renders as:

```
type Foo = (FooBarBaz
            QuxQuuxQuz -> FooBarBaz
                          QuxQuuxQuz -> FooBarBaz
                                        QuxQuuxQuz -> FooBarBaz
                                                      QuxQuuxQuz)
```

How do we wish to format this? I can work on it once we've decided on a path

I'm leaning towards:

```
type Foo = ( FooBarBaz QuxQuuxQuz
             -> FooBarBaz QuxQuuxQuz
             -> FooBarBaz QuxQuuxQuz
             -> FooBarBaz QuxQuuxQuz
           )
```

Or perhaps we can even remove the parenthesis?