### PR TITLE
Fix license identifiers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "purescript-ps-cst",
     "license": [
-        "Apache-2.0"
+        "BSD-3-Clause"
     ],
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "purescript-ps-cst",
   "version": "1.0.0",
   "repository": "https://github.com/purescript-codegen/purescript-ps-cst",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "devDependencies": {
     "disparity": "^3.0.0"
   }

--- a/spago.dhall
+++ b/spago.dhall
@@ -25,6 +25,6 @@
     ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
-, license = "Apache-2.0"
+, license = "BSD-3-Clause"
 , repository = "https://github.com/purescript-codegen/purescript-ps-cst"
 }


### PR DESCRIPTION
This PR fixes up the license identifiers in various files to:
1. Match the license specified in the LICENSE file
2. Be valid SPDX license identifiers

### Motivation

`ps-cst` is currently in the PureScript [package set](https://github.com/purescript/package-sets) and will need to have this license issue addressed in order to remain in the package set after the move to the new PureScript registry.

See https://github.com/purescript/registry/issues/250 for more details.